### PR TITLE
✨ Allow access to httpclient in inherited classes

### DIFF
--- a/src/FreshBooksClient.php
+++ b/src/FreshBooksClient.php
@@ -32,7 +32,8 @@ use amcintosh\FreshBooks\Resource\AuthResource;
 
 class FreshBooksClient
 {
-    private ClientInterface $httpClient;
+    protected ClientInterface $httpClient;
+
     private RequestFactoryInterface $requestFactoryInterface;
     private StreamFactoryInterface $streamFactoryInterface;
 


### PR DESCRIPTION
If a class inherits from FreshBooksClient, it should be able to access the httpClient, especially as createHttpClient is already protected. This will aid in allowing developers to extend the client to cover API endpoints not yet supported (or with fields not yet supported). 

Closes #22