### PR TITLE
🐛 Update quantity on invoice lines to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support for items
 - Support for tasks
+- Change quantity field on invoice lines and items to float
 
 ## 0.3.0
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -61,7 +61,7 @@ class Item extends DataTransferObject implements DataModel
      */
     #[MapFrom('qty')]
     #[MapTo('qty')]
-    public ?int $quantity;
+    public ?float $quantity;
 
     /**
      * @var string Id for a specific item or product, used in inventory management.

--- a/src/Model/LineItem.php
+++ b/src/Model/LineItem.php
@@ -67,7 +67,7 @@ class LineItem extends DataTransferObject implements DataModel
      */
     #[MapFrom('qty')]
     #[MapTo('qty')]
-    public ?int $quantity;
+    public ?float $quantity;
 
     /**
      * @var string First tax amount, in percentage, up to 3 decimal places.

--- a/tests/Model/InvoiceTest.php
+++ b/tests/Model/InvoiceTest.php
@@ -263,7 +263,7 @@ final class InvoiceTest extends TestCase
         $this->assertSame('Melmac melamine resin molded dinnerware', $line->description);
         $this->assertSame(0, $line->expenseId);
         $this->assertSame('Bowls', $line->name);
-        $this->assertSame(4, $line->quantity);
+        $this->assertSame(4.0, $line->quantity);
         $this->assertSame('13', $line->taxAmount1);
         $this->assertSame('0', $line->taxAmount2);
         $this->assertSame('HST1', $line->taxName1);
@@ -317,7 +317,7 @@ final class InvoiceTest extends TestCase
                     'description' => 'Melmac melamine resin molded dinnerware',
                     'expenseid' => 0,
                     'name' => 'Bowls',
-                    'qty' => 4,
+                    'qty' => 4.0,
                     'taxAmount1' => '13',
                     'taxAmount2' => '0',
                     'taxName1' => 'HST1',
@@ -339,7 +339,7 @@ final class InvoiceTest extends TestCase
                     'description' => 'Melmac melamine resin molded mug',
                     'expenseid' => 0,
                     'name' => 'Mugs',
-                    'qty' => 6,
+                    'qty' => 6.0,
                     'taxAmount1' => '0',
                     'taxAmount2' => '0',
                     'taxName1' => '',
@@ -411,7 +411,7 @@ final class InvoiceTest extends TestCase
                     'description' => 'Melmac melamine resin molded dinnerware',
                     'expenseid' => 0,
                     'name' => 'Bowls',
-                    'qty' => 4,
+                    'qty' => 4.0,
                     'taxAmount1' => '13',
                     'taxAmount2' => '0',
                     'taxName1' => 'HST1',
@@ -433,7 +433,7 @@ final class InvoiceTest extends TestCase
                     'description' => 'Melmac melamine resin molded mug',
                     'expenseid' => 0,
                     'name' => 'Mugs',
-                    'qty' => 6,
+                    'qty' => 6.0,
                     'taxAmount1' => '0',
                     'taxAmount2' => '0',
                     'taxName1' => '',

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -44,7 +44,7 @@ final class ItemTest extends TestCase
         $this->assertSame('Melmac melamine resin molded dinnerware', $item->description);
         $this->assertSame('50', $item->inventory);
         $this->assertSame('Bowls', $item->name);
-        $this->assertSame(4, $item->quantity);
+        $this->assertSame(4.0, $item->quantity);
         $this->assertSame('SQ8608333', $item->sku);
         $this->assertSame(2, $item->tax1);
         $this->assertSame(0, $item->tax2);
@@ -62,7 +62,7 @@ final class ItemTest extends TestCase
             'description' => 'Melmac melamine resin molded dinnerware',
             'inventory' => '50',
             'name' => 'Bowls',
-            'qty' => 4,
+            'qty' => 4.0,
             'sku' => 'SQ8608333',
             'tax1' => 2,
             'tax2' => 0,


### PR DESCRIPTION
FreshBooks allows you to set partial quantities using a string floating point number.

Fixes #28