### PR TITLE
♻️ Refactor accounting list models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added list sort builder
+- Updated list models with new `pages()` function to standardize pagination with different models
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -309,10 +309,10 @@ Pagination results are included in `list` responses:
 ```php
 $clients = $freshBooksClient->clients()->list($accountId);
 
-echo $clients->page    // 1
-echo $clients->pages   // 1
-echo $clients->perPage // 30
-echo $clients->total   // 6
+echo $clients->pages()->page    // 1
+echo $clients->pages()->pages   // 1
+echo $clients->pages()->perPage // 30
+echo $clients->pages()->total   // 6
 ```
 
 To make a paginated call, first create a `PaginateBuilder` that can be passed into the `list` method.
@@ -324,10 +324,10 @@ $paginator = new PaginateBuilder(2, 4);
 
 $clients = $freshBooksClient->clients()->list($accountId, builders: [$paginator]);
 
-echo $clients->page    // 2
-echo $clients->pages   // 2
-echo $clients->perPage // 4
-echo $clients->total   // 6
+echo $clients->pages()->page    // 2
+echo $clients->pages()->pages   // 2
+echo $clients->pages()->perPage // 4
+echo $clients->pages()->total   // 6
 ```
 
 `PaginateBuilder` has chainable methods `page` and `perPage` to set the values.

--- a/docs/source/api-calls/builders.rst
+++ b/docs/source/api-calls/builders.rst
@@ -14,10 +14,10 @@ Pagination results are included in :doc:`list<get-list>` responses:
 .. code-block:: php
     $clients = $freshBooksClient->clients()->list($accountId);
 
-    echo $clients->page    // 1
-    echo $clients->pages   // 1
-    echo $clients->perPage // 30
-    echo $clients->total   // 6
+    echo $clients->pages()->page    // 1
+    echo $clients->pages()->pages   // 1
+    echo $clients->pages()->perPage // 30
+    echo $clients->pages()->total   // 6
 
 To make a paginated call, first create a ``PaginateBuilder`` that can be passed into the ``list`` method.
 
@@ -28,10 +28,10 @@ To make a paginated call, first create a ``PaginateBuilder`` that can be passed 
 
     $clients = $freshBooksClient->clients()->list($accountId, builders: [$paginator]);
 
-    echo $clients->page    // 2
-    echo $clients->pages   // 2
-    echo $clients->perPage // 4
-    echo $clients->total   // 6
+    echo $clients->pages()->page    // 2
+    echo $clients->pages()->pages   // 2
+    echo $clients->pages()->perPage // 4
+    echo $clients->pages()->total   // 6
 
 ``PaginateBuilder`` has chainable methods ``page`` and ``perPage`` to set the values.
 

--- a/src/Model/AccountingList.php
+++ b/src/Model/AccountingList.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace amcintosh\FreshBooks\Model;
+
+use Spatie\DataTransferObject\Attributes\MapFrom;
+use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\Pages;
+
+/**
+ * Parent class for list results on acocunting endpoints to share pagination details.
+ *
+ * @package amcintosh\FreshBooks\Model
+ */
+class AccountingList extends DataTransferObject
+{
+    public int $page;
+
+    public int $pages;
+
+    #[MapFrom('per_page')]
+    public int $perPage;
+
+    public int $total;
+
+    public function pages(): mixed
+    {
+        return new Pages($this->page, $this->pages, $this->perPage, $this->total);
+    }
+}

--- a/src/Model/ClientList.php
+++ b/src/Model/ClientList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Client;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Client;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/clients
  */
-class ClientList extends DataTransferObject
+class ClientList extends AccountingList
 {
     public const RESPONSE_FIELD = 'clients';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Client::class)]
     public array $clients;

--- a/src/Model/ExpenseAttachment.php
+++ b/src/Model/ExpenseAttachment.php
@@ -13,7 +13,6 @@ use Spatie\DataTransferObject\Caster;
 use Spatie\DataTransferObject\DataTransferObject;
 use amcintosh\FreshBooks\Model\DataModel;
 use amcintosh\FreshBooks\Model\Caster\AccountingDateTimeImmutableCaster;
-use amcintosh\FreshBooks\Model\Caster\DateCaster;
 use amcintosh\FreshBooks\Model\Caster\MoneyCaster;
 
 /**

--- a/src/Model/ExpenseList.php
+++ b/src/Model/ExpenseList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Expense;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Expense;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/expenses
  */
-class ExpenseList extends DataTransferObject
+class ExpenseList extends AccountingList
 {
     public const RESPONSE_FIELD = 'expenses';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Expense::class)]
     public array $expenses;

--- a/src/Model/InvoiceList.php
+++ b/src/Model/InvoiceList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Invoice;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Invoice;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/invoices
  */
-class InvoiceList extends DataTransferObject
+class InvoiceList extends AccountingList
 {
     public const RESPONSE_FIELD = 'invoices';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Invoice::class)]
     public array $invoices;

--- a/src/Model/ItemList.php
+++ b/src/Model/ItemList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Item;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Item;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/items
  */
-class ItemList extends DataTransferObject
+class ItemList extends AccountingList
 {
     public const RESPONSE_FIELD = 'items';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Item::class)]
     public array $items;

--- a/src/Model/Pages.php
+++ b/src/Model/Pages.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace amcintosh\FreshBooks\Model;
+
+/**
+ * List call pagination details.
+ *
+ * @package amcintosh\FreshBooks\Model
+ */
+class Pages
+{
+    public int $page;
+
+    public int $pages;
+
+    public int $perPage;
+
+    public int $total;
+
+    /**
+     * __construct Create a pages object
+     *
+     * @param  int $page The current page of results
+     * @param  int $pages The number of pages of results
+     * @param  int $perPage The number of results in each page
+     * @param  int $total The total number of results
+     * @return void
+     */
+    public function __construct(int $page, int $pages, int $perPage, int $total)
+    {
+        $this->page = $page;
+        $this->pages = $pages;
+        $this->perPage = $perPage;
+        $this->total = $total;
+    }
+}

--- a/src/Model/PaymentList.php
+++ b/src/Model/PaymentList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Payment;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Payment;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/payments
  */
-class PaymentList extends DataTransferObject
+class PaymentList extends AccountingList
 {
     public const RESPONSE_FIELD = 'payments';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Payment::class)]
     public array $payments;

--- a/src/Model/TaskList.php
+++ b/src/Model/TaskList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Task;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Task;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/tasks
  */
-class TaskList extends DataTransferObject
+class TaskList extends AccountingList
 {
     public const RESPONSE_FIELD = 'tasks';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Task::class)]
     public array $tasks;

--- a/src/Model/TaxList.php
+++ b/src/Model/TaxList.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace amcintosh\FreshBooks\Model;
 
 use Spatie\DataTransferObject\Attributes\CastWith;
-use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
-use Spatie\DataTransferObject\DataTransferObject;
+use amcintosh\FreshBooks\Model\AccountingList;
 use amcintosh\FreshBooks\Model\Tax;
 
 /**
@@ -16,18 +15,9 @@ use amcintosh\FreshBooks\Model\Tax;
  * @package amcintosh\FreshBooks\Model
  * @link https://www.freshbooks.com/api/taxes
  */
-class TaxList extends DataTransferObject
+class TaxList extends AccountingList
 {
     public const RESPONSE_FIELD = 'taxes';
-
-    public int $page;
-
-    public int $pages;
-
-    #[MapFrom('per_page')]
-    public int $perPage;
-
-    public int $total;
 
     #[CastWith(ArrayCaster::class, itemType: Tax::class)]
     public array $taxes;

--- a/src/Resource/AccountingResource.php
+++ b/src/Resource/AccountingResource.php
@@ -185,6 +185,16 @@ class AccountingResource extends BaseResource
         return new $this->singleModel($result[$this->singleModel::RESPONSE_FIELD]);
     }
 
+    /**
+     * Delete a resource.
+     *
+     * Note: Most FreshBooks resources are soft-deleted,
+     * See [FreshBooks API - Active and Deleted Objects](https://www.freshbooks.com/api/active_deleted)
+     *
+     * @param  string $accountId The alpha-numeric account id
+     * @param  int $resourceId Id of the resource to delete
+     * @return DataTransferObject Null for some resources or the Model of the deleted resource's response data.
+     */
     public function delete(string $accountId, int $resourceId): ?DataTransferObject
     {
         if ($this->deleteViaUpdate) {

--- a/tests/FreshBooksClientTest.php
+++ b/tests/FreshBooksClientTest.php
@@ -94,7 +94,7 @@ final class FreshBooksClientTest extends TestCase
         );
         $client = new MockFreshBooksClient('some_client_id', $conf);
 
-        $client->getAccessToken('1234');
+        $this->assertSame($returnToken, $client->getAccessToken('1234'));
     }
 
     public function testGetAccessTokenSecretRequired(): void
@@ -153,7 +153,7 @@ final class FreshBooksClientTest extends TestCase
         );
         $client = new MockFreshBooksClient('some_client_id', $conf);
 
-        $client->refreshAccessToken('1234');
+        $this->assertSame($returnToken, $client->refreshAccessToken('1234'));
     }
 
     public function testRefreshAccessTokenFromConfiguration(): void
@@ -181,7 +181,7 @@ final class FreshBooksClientTest extends TestCase
         );
         $client = new MockFreshBooksClient('some_client_id', $conf);
 
-        $client->refreshAccessToken();
+        $this->assertSame($returnToken, $client->refreshAccessToken());
     }
 
     public function testRefreshAccessTokenCurrentRefreshRequired(): void

--- a/tests/Model/ClientListTest.php
+++ b/tests/Model/ClientListTest.php
@@ -131,10 +131,10 @@ final class ClientListTest extends TestCase
 
         $clients = new ClientList($clientData);
 
-        $this->assertSame(1, $clients->page);
-        $this->assertSame(1, $clients->pages);
-        $this->assertSame(15, $clients->perPage);
-        $this->assertSame(2, $clients->total);
+        $this->assertSame(1, $clients->pages()->page);
+        $this->assertSame(1, $clients->pages()->pages);
+        $this->assertSame(15, $clients->pages()->perPage);
+        $this->assertSame(2, $clients->pages()->total);
 
         $this->assertSame(12345, $clients->clients[0]->id);
         $this->assertSame('gordon.shumway@AmericanCyanamid.com', $clients->clients[0]->email);


### PR DESCRIPTION
Moving pagination details on list models into parent class for less
repetition. Also adding a 'pages()' function to return the pagination
details in a separate object. This will allow us to access pagination
data in the same way across resource types when we implement project
resources, which put the pagination data in a separate place.