### PR TITLE
Add Retry plugin to http client

### DIFF
--- a/src/FreshBooksClient.php
+++ b/src/FreshBooksClient.php
@@ -7,6 +7,7 @@ namespace amcintosh\FreshBooks;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin\BaseUriPlugin;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
+use Http\Client\Common\Plugin\RetryPlugin;
 use Http\Client\Common\PluginClientFactory;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
@@ -80,6 +81,10 @@ class FreshBooksClient
             new BaseUriPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri($this->config->apiBaseUrl)),
             new HeaderDefaultsPlugin($this->getHeaders()),
         );
+
+        if ($this->config->autoRetry) {
+            $plugins[] = new RetryPlugin();
+        }
 
         $pluginClient = (new PluginClientFactory())->createClient(
             HttpClientDiscovery::find(),

--- a/src/FreshBooksClient.php
+++ b/src/FreshBooksClient.php
@@ -83,7 +83,7 @@ class FreshBooksClient
         );
 
         if ($this->config->autoRetry) {
-            $plugins[] = new RetryPlugin();
+            $plugins[] = new RetryPlugin(['retries' => $this->config->retries]);
         }
 
         $pluginClient = (new PluginClientFactory())->createClient(

--- a/src/FreshBooksClientConfig.php
+++ b/src/FreshBooksClientConfig.php
@@ -24,6 +24,7 @@ class FreshBooksClientConfig
     public ?DateTimeImmutable $tokenExpiresAt;
     public ?string $userAgent;
     public bool $autoRetry;
+    public int $retries;
     public int $timeout;
     public string $version;
 
@@ -39,6 +40,7 @@ class FreshBooksClientConfig
         ?string $refreshToken = null,
         ?string $userAgent = null,
         bool $autoRetry = true,
+        int $retries = 3,
         int $timeout = self::DEFAULT_TIMEOUT
     ) {
         $this->apiBaseUrl = self::API_BASE_URL;
@@ -51,6 +53,7 @@ class FreshBooksClientConfig
         $this->tokenExpiresAt = null;
         $this->userAgent = $userAgent;
         $this->autoRetry = $autoRetry;
+        $this->retries = $retries;
         $this->timeout = $timeout;
         $this->version = $this->getVersion();
     }


### PR DESCRIPTION
Hi 👋 

This addresses Issue #5 but two things are left to do:
* Test that the Retry plugin can be disabled (Can you point me in the right direction on how I would go about this?)
* Allow configuration of the plugin by passing an `options` array to it. Should this also be configurable in `FreshBooksClientConfig`? Maybe via a simple array?

Also, I'm trying to contribute to Hacktoberfest. Could you label the issue with _hacktoberfest_?