### PR TITLE
🐛 Make invoice line TaxNumber read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added Expense Categories resource
 - Added list sort builder
 - Updated list models with new `pages()` function to standardize pagination with different models
+- Make invoice LineItem's taxNumber1 and taxNumber2 readonly due to FreshBooks API change
 
 ## 0.5.0
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "spryker/decimal-object": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.5.x-dev",
+        "phpunit/phpunit": "9.6.x-dev",
         "squizlabs/php_codesniffer": "4.0.x-dev",
         "php-http/guzzle7-adapter": "1.x-dev",
         "php-http/mock-client": "1.x-dev",

--- a/src/Model/LineItem.php
+++ b/src/Model/LineItem.php
@@ -10,7 +10,6 @@ use Spatie\DataTransferObject\Attributes\MapFrom;
 use Spatie\DataTransferObject\Attributes\MapTo;
 use Spatie\DataTransferObject\Caster;
 use Spatie\DataTransferObject\DataTransferObject;
-use amcintosh\FreshBooks\Model\DataModel;
 use amcintosh\FreshBooks\Model\Caster\AccountingDateTimeImmutableCaster;
 use amcintosh\FreshBooks\Model\Caster\MoneyCaster;
 
@@ -26,7 +25,7 @@ use amcintosh\FreshBooks\Model\Caster\MoneyCaster;
  */
 class LineItem extends DataTransferObject
 {
-    protected array $exceptKeys = ['amount', 'updated'];
+    protected array $exceptKeys = ['amount', 'taxNumber1', 'taxNumber2', 'updated'];
 
     /**
      * @var int Unique-to-this-invoice line id.

--- a/tests/Model/InvoiceTest.php
+++ b/tests/Model/InvoiceTest.php
@@ -322,8 +322,6 @@ final class InvoiceTest extends TestCase
                     'taxAmount2' => '0',
                     'taxName1' => 'HST1',
                     'taxName2' => null,
-                    'taxNumber1' => 'RT',
-                    'taxNumber2' => null,
                     'type' => 0,
                     'unit_cost' => [
                         'amount' => '5.00',
@@ -340,8 +338,6 @@ final class InvoiceTest extends TestCase
                     'taxAmount2' => '0',
                     'taxName1' => '',
                     'taxName2' => '',
-                    'taxNumber1' => null,
-                    'taxNumber2' => null,
                     'type' => 0,
                     'unit_cost' => [
                         'amount' => '4.00',
@@ -417,8 +413,6 @@ final class InvoiceTest extends TestCase
                     'taxAmount2' => '0',
                     'taxName1' => 'HST1',
                     'taxName2' => null,
-                    'taxNumber1' => 'RT',
-                    'taxNumber2' => null,
                     'type' => 0,
                     'unit_cost' => [
                         'amount' => '5.00',
@@ -435,8 +429,6 @@ final class InvoiceTest extends TestCase
                     'taxAmount2' => '0',
                     'taxName1' => '',
                     'taxName2' => '',
-                    'taxNumber1' => null,
-                    'taxNumber2' => null,
                     'type' => 0,
                     'unit_cost' => [
                         'amount' => '4.00',


### PR DESCRIPTION
There appears to have been a change in the FreshBooks API in the last 2 weeks making the TaxNumber1 and TaxNumber2 fields on invoice line items readonly. Changing the model to no longer send them.

Fixes #51