### PR TITLE
✨  Support new API version error format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove warnings in PHP 8.2
+- Handle new API version accounting errors
 
 ## 0.6.0
 

--- a/src/Exception/FreshBooksException.php
+++ b/src/Exception/FreshBooksException.php
@@ -8,18 +8,21 @@ final class FreshBooksException extends \Exception
 {
     public ?string $rawResponse;
     public ?int $errorCode;
+    public ?array $errorDetails;
 
     public function __construct(
         string $message,
         int $statusCode,
         Throwable $previous = null,
         string $rawResponse = null,
-        int $errorCode = null
+        int $errorCode = null,
+        array $errorDetails = null
     ) {
         parent::__construct($message, $statusCode, $previous);
 
         $this->rawResponse = $rawResponse;
         $this->errorCode = $errorCode;
+        $this->errorDetails = $errorDetails;
     }
 
     public function getRawResponse(): ?string
@@ -30,5 +33,10 @@ final class FreshBooksException extends \Exception
     public function getErrorCode(): ?int
     {
         return $this->errorCode;
+    }
+
+    public function getErrorDetails(): ?array
+    {
+        return $this->errorDetails;
     }
 }

--- a/tests/Resource/BaseResourceTest.php
+++ b/tests/Resource/BaseResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace amcintosh\FreshBooks\Tests\Resource;
 
+use GuzzleHttp\Psr7;
 use Http\Discovery\Psr17FactoryDiscovery;
 use amcintosh\FreshBooks\Tests\Util\MockHttpClient;
 
@@ -15,12 +16,10 @@ trait BaseResourceTest
             Psr17FactoryDiscovery::findRequestFactory(),
             Psr17FactoryDiscovery::findStreamFactory()
         );
-        $mockContent = $this->getMockBuilder(\stdclass::class)->setMethods(['getContents'])->getMock();
-        $mockContent->method('getContents')->will($this->returnValue(json_encode($content)));
 
         $response = $this->createMock('Psr\Http\Message\ResponseInterface');
         $response->method('getStatusCode')->will($this->returnValue($status));
-        $response->method('getBody')->will($this->returnValue($mockContent));
+        $response->method('getBody')->will($this->returnValue(Psr7\Utils::streamFor(json_encode($content))));
         $mockHttpClient->addResponse($response);
         return $mockHttpClient;
     }

--- a/tests/Resource/ProjectResourceTest.php
+++ b/tests/Resource/ProjectResourceTest.php
@@ -310,6 +310,37 @@ final class ProjectResourceTest extends TestCase
         );
     }
 
+    public function testCreateValidationErrors(): void
+    {
+        $mockHttpClient = $this->getMockHttpClient(
+            422,
+            [
+                'errno' => 2001,
+                'error' => [
+                    'title' => 'field required',
+                    'description' => 'field required'
+                ]
+            ]
+        );
+
+        $resource = new ProjectResource($mockHttpClient, 'projects', 'projects', Project::class, ProjectList::class);
+
+        try {
+            $resource->create($this->businessId, data: []);
+            $this->fail('FreshBooksException was not thrown');
+        } catch (FreshBooksException $e) {
+            $this->assertSame('Error: description field required', $e->getMessage());
+            $this->assertSame(422, $e->getCode());
+            $this->assertSame(
+                [
+                    ['title' => 'field required'],
+                    ['description' => 'field required']
+                ],
+                $e->getErrorDetails()
+            );
+        }
+    }
+
     public function testUpdateByModel(): void
     {
         $projectId = 12345;


### PR DESCRIPTION
While FreshBooks API versions are not yet documented, the recent versions (2022-10-31 and forward) feature a slightly different response format when some /accounting endpoints fail.

Update the accounting handlers to handle both formats.