### PR TITLE
✨ Update events resource to handle new error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support for PHP 8.3
+- Handle new API version webhook event errors
 
 ## 0.7.0
 

--- a/src/Resource/EventsResource.php
+++ b/src/Resource/EventsResource.php
@@ -45,23 +45,17 @@ class EventsResource extends AccountingResource
      */
     protected function handleError(int $statusCode, array $responseData, string $rawRespone): void
     {
-        if (!array_key_exists('message', $responseData) || !array_key_exists('code', $responseData)) {
+        if (!array_key_exists('message', $responseData)) {
             throw new FreshBooksException('Unknown error', $statusCode, null, $rawRespone);
         }
 
         $message = $responseData['message'];
-        $errorCode = null;
         $details = [];
-
-        foreach ($responseData['details'] as $detail) {
-            if (
-                in_array('type.googleapis.com/google.rpc.BadRequest', $detail)
-                && array_key_exists('fieldViolations', $detail)
-            ) {
-                $details = $detail['fieldViolations'];
-            }
+        if (array_key_exists('details', $responseData)) {
+            $details = $responseData['details'];
         }
-        throw new FreshBooksException($message, $statusCode, null, $rawRespone, $errorCode, $details);
+
+        throw new FreshBooksException($message, $statusCode, null, $rawRespone, null, $details);
     }
 
     /**

--- a/tests/Resource/EventsResourceTest.php
+++ b/tests/Resource/EventsResourceTest.php
@@ -46,17 +46,8 @@ final class EventsResourceTest extends TestCase
         $mockHttpClient = $this->getMockHttpClient(
             404,
             [
-                'code' => 5,
-                'message' => 'Requested resource could not be found.',
-                'details' => [
-                    [
-                        '@type' => 'type.googleapis.com/google.rpc.Help',
-                        'links' => [
-                            'description' => 'API Documentation',
-                            'url' => 'https://www.freshbooks.com/api/webhooks',
-                        ]
-                    ]
-                ]
+                'errno' => 404,
+                'message' => 'Requested resource could not be found.'
             ]
         );
 
@@ -79,26 +70,9 @@ final class EventsResourceTest extends TestCase
         $mockHttpClient = $this->getMockHttpClient(
             400,
             [
-                'code' => 3,
-                'message' => 'Invalid data in this request.',
-                'details' => [
-                    [
-                        '@type' => 'type.googleapis.com/google.rpc.BadRequest',
-                        'fieldViolations' => [
-                            [
-                                'field' => 'event',
-                                'description' => 'Value error, Unrecognized event.'
-                            ]
-                        ]
-                    ],
-                    [
-                        '@type' => 'type.googleapis.com/google.rpc.Help',
-                        'links' => [
-                            'description' => 'API Documentation',
-                            'url' => 'https://www.freshbooks.com/api/webhooks',
-                        ]
-                    ]
-                ]
+                'errno' => 3,
+                'message' => 'The request was well-formed but was unable to be followed due to semantic errors.'
+                    . '\nevent: Value error, Unrecognized event.'
             ]
         );
 
@@ -108,13 +82,11 @@ final class EventsResourceTest extends TestCase
             $resource->create($this->accountId, data: []);
             $this->fail('FreshBooksException was not thrown');
         } catch (FreshBooksException $e) {
-            $this->assertSame('Invalid data in this request.', $e->getMessage());
+            $this->assertSame('The request was well-formed but was unable to be followed due to semantic errors.'
+                . '\nevent: Value error, Unrecognized event.', $e->getMessage());
             $this->assertSame(400, $e->getCode());
             $this->assertNull($e->getErrorCode());
-            $this->assertSame([[
-                'field' => 'event',
-                'description' => 'Value error, Unrecognized event.'
-            ]], $e->getErrorDetails());
+            $this->assertSame([], $e->getErrorDetails());
         }
     }
 


### PR DESCRIPTION
The error response for the events API has changed. The events resource needs to be updated to handle the new error responses. Currently all errors are creating exceptions with "Unknwon error" as the message.

Closes #65