### PR TITLE
Update run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
     - name: Setup
@@ -24,7 +24,7 @@ jobs:
 
     - name: Cache composer dependencies
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
# Add PHP 8.4 support to CI workflow

## Description
This PR upgrades the CI workflow to include PHP 8.4 testing, as requested in issue #69. The changes ensure the FreshBooks PHP SDK is tested against the latest PHP version for better compatibility and future-proofing.

## Changes Made
- ✅ Added PHP 8.4 to the test matrix in `.github/workflows/run-tests.yml`
- ✅ Updated `actions/cache` from v2 to v4 for improved performance and compatibility
- ✅ Maintained backward compatibility with existing PHP versions (8.0, 8.1, 8.2, 8.3)

## Files Changed
- `.github/workflows/run-tests.yml`

## Testing
- [x] All existing PHP versions (8.0-8.3) continue to be tested
- [x] New PHP 8.4 testing added to the matrix
- [x] Updated cache action maintains functionality while improving performance

## Verification
The updated workflow will now test against:
- PHP 8.0
- PHP 8.1  
- PHP 8.2
- PHP 8.3
- **PHP 8.4** (newly added)

## Benefits
1. **Future-ready**: Ensures compatibility with the latest PHP release
2. **Better CI performance**: Updated cache action provides faster builds
3. **Comprehensive testing**: Maintains full test coverage across all supported PHP versions
4. **Developer confidence**: Early detection of PHP 8.4 compatibility issues

## Closes
Closes #69

## Checklist
- [x] I have tested these changes locally
- [x] The changes maintain backward compatibility
- [x] The CI workflow syntax is valid
- [x] Documentation is not required for this change
- [x] This change follows the project's contributing guidelines

---

**Note**: This PR specifically addresses the Hacktoberfest-labeled issue for upgrading CI to support PHP 8.4. The changes are minimal and focused, ensuring no disruption to existing functionality while adding the requested PHP version support.